### PR TITLE
Add 'fork me on github' ribbon support for the main theme.

### DIFF
--- a/flask/layout.html
+++ b/flask/layout.html
@@ -6,7 +6,12 @@
   {% endif %}
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9">
 {% endblock %}
-{%- block relbar2 %}{% endblock %}
+{%- block relbar2 %}
+  {% if theme_github_fork %}
+    <a href="http://github.com/{{ theme_github_fork }}"><img style="position: fixed; top: 0; right: 0; border: 0;"
+    src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
+  {% endif %}
+{% endblock %}
 {% block header %}
   {{ super() }}
   {% if pagename == 'index' %}

--- a/flask/theme.conf
+++ b/flask/theme.conf
@@ -7,3 +7,4 @@ pygments_style = flask_theme_support.FlaskyStyle
 index_logo = ''
 index_logo_height = 120px
 touch_icon = 
+github_fork = ''


### PR DESCRIPTION
The ribbon was only available on the flask_small theme. I copied it from that.  This patch is in use on this docs page: https://pystmark.readthedocs.org/en/latest/