### PR TITLE
Make reference links more consistent and identifiable

### DIFF
--- a/flask/static/flasky.css_t
+++ b/flask/static/flasky.css_t
@@ -365,8 +365,11 @@ tt {
 }
 
 tt.xref, a tt {
-    background-color: #FBFBFB;
-    border-bottom: 1px solid white;
+    color: #004B6B;
+}
+
+tt.xref:hover, a:hover tt {
+    color: #6D4100;
 }
 
 a.reference {
@@ -388,11 +391,6 @@ a.footnote-reference {
 a.footnote-reference:hover {
     border-bottom: 1px solid #6D4100;
 }
-
-a:hover tt {
-    background: #EEE;
-}
-
 
 @media screen and (max-width: 870px) {
 

--- a/flask/static/flasky.css_t
+++ b/flask/static/flasky.css_t
@@ -364,11 +364,11 @@ tt {
     /* padding: 1px 2px; */
 }
 
-tt.xref, a tt {
+a tt {
     color: #004B6B;
 }
 
-tt.xref:hover, a:hover tt {
+a:hover tt {
     color: #6D4100;
 }
 

--- a/flask_small/static/flasky.css_t
+++ b/flask_small/static/flasky.css_t
@@ -278,10 +278,10 @@ tt {
     /* padding: 1px 2px; */
 }
 
-tt.xref, a tt {
-    background-color: #FBFBFB;
+a tt {
+    color: #004B6B;
 }
 
 a:hover tt {
-    background: #EEE;
+    color: #6D4100;
 }


### PR DESCRIPTION
This addresses mitsuhiko/flask#923.

Updates the style of reference links to be closer to that of normal links to differentiate them from their non-link counterparts. Here's an example:

![screen shot 2014-02-13 at 12 18 01 pm](https://f.cloud.github.com/assets/55005/2162497/db64afaa-94d2-11e3-8230-39f4255e3519.png)
