### PR TITLE
Improve Monospace Font Stack on GNU/Linux Systems

### DIFF
--- a/flask/static/flasky.css_t
+++ b/flask/static/flasky.css_t
@@ -252,7 +252,7 @@ p.admonition-title:after {
 }
 
 pre, tt {
-    font-family: 'Consolas', 'Menlo', 'Deja Vu Sans Mono', 'Bitstream Vera Sans Mono', monospace;
+    font-family: 'Consolas', 'Menlo', 'Liberation Mono', 'Deja Vu Sans Mono', 'Bitstream Vera Sans Mono', monospace;
     font-size: 0.9em;
 }
 

--- a/flask_small/static/flasky.css_t
+++ b/flask_small/static/flasky.css_t
@@ -188,7 +188,7 @@ p.admonition-title:after {
 }
 
 pre, tt {
-    font-family: 'Consolas', 'Menlo', 'Deja Vu Sans Mono', 'Bitstream Vera Sans Mono', monospace;
+    font-family: 'Consolas', 'Menlo', 'Liberation Mono', 'Deja Vu Sans Mono', 'Bitstream Vera Sans Mono', monospace;
     font-size: 0.85em;
 }
 


### PR DESCRIPTION
DejaVu Sans Mono is quite hard to read when rendered in the browser on GNU/Linux systems. I propose adding Liberation Mono to the monospace font stack between Menlo and DejaVu Sans Mono. I think is a big improvement for users who are running similar systems and have this font installed.

##### DejaVu Sans Mono
> ![screenshot from 2014-11-16 13 00 50](https://cloud.githubusercontent.com/assets/3788970/5061500/51c4675c-6d91-11e4-8730-391568e0b333.png)

##### Liberation Mono
> ![screenshot from 2014-11-16 13 00 35](https://cloud.githubusercontent.com/assets/3788970/5061499/518d5442-6d91-11e4-9b39-0a920de0c58b.png)