### PR TITLE
change http:// to https:// links

### DIFF
--- a/flask/layout.html
+++ b/flask/layout.html
@@ -10,9 +10,9 @@
 
 {% block relbar2 %}
     {% if theme_github_fork %}
-        <a href="http://github.com/{{ theme_github_fork }}">
+        <a href="https://github.com/{{ theme_github_fork }}">
             <img style="position: fixed; top: 0; right: 0; border: 0;"
-                 src="http://s3.amazonaws.com/github/ribbons/forkme_right_{{ theme_github_ribbon_color }}.png"
+                 src="https://s3.amazonaws.com/github/ribbons/forkme_right_{{ theme_github_ribbon_color }}.png"
                  alt="Fork me on GitHub">
         </a>
     {% endif %}

--- a/flask_small/layout.html
+++ b/flask_small/layout.html
@@ -25,9 +25,9 @@
 
 {% block relbar2 %}
     {% if theme_github_fork %}
-        <a href="http://github.com/{{ theme_github_fork }}">
+        <a href="https://github.com/{{ theme_github_fork }}">
             <img style="position: fixed; top: 0; right: 0; border: 0;"
-                 src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"
+                 src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"
                  alt="Fork me on GitHub">
         </a>
     {% endif %}


### PR DESCRIPTION
This addresses a mixed-content warning on https://pythonhosted.org/itsdangerous/